### PR TITLE
chore: pin the version of numpy in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+numpy==1.26.4
 rdflib==7.0.0
 SPARQLWrapper==2.0.0
 tqdm==4.66.1


### PR DESCRIPTION
This fixes the following error when loading the tokenizer:

> A module that was compiled using NumPy 1.x cannot be run in
> NumPy 2.0.0 as it may crash. To support both 1.x and 2.x
> versions of NumPy, modules must be compiled with NumPy 2.0.
> Some module may need to rebuild instead e.g. with 'pybind11>=2.12'.