### PR TITLE
fix: import missing urlparse function

### DIFF
--- a/update_KG.py
+++ b/update_KG.py
@@ -12,6 +12,7 @@ import torch
 import torch.nn as nn
 from transformers import BertForPreTraining, AutoTokenizer
 import trafilatura
+from urllib.parse import urlparse
 
 import os
 


### PR DESCRIPTION
This fixes the following error when converting:

> Traceback (most recent call last):
>   File "/data/converter/update_KG.py", line 182, in <module>
>     review_url_parsed = urlparse(review_url.lower())
> NameError: name 'urlparse' is not defined. Did you mean: 'argparse'?