### PR TITLE
fix: move the initialization of errors list before its first use

### DIFF
--- a/update_KG.py
+++ b/update_KG.py
@@ -163,6 +163,7 @@ model_con.eval()
 
 need_extract = 0
 need_convert = 0
+errors = []
 
 print('Extracting factors, entities and text from new claim reviews')
 dict_factors_entities_text = {}
@@ -230,7 +231,6 @@ for cr in cr_new:
         all_organizations_websites.append(website)
 
 
-errors = []
 
 
 print('Updating Graph')


### PR DESCRIPTION
This fixes the following error when converting:

> Traceback (most recent call last):
>   File "/data/converter/update_KG.py", line 174, in <module>
>     errors.append(i)
> NameError: name 'errors' is not defined